### PR TITLE
add ability to query truncated 30-day tweets to TweetRetriever

### DIFF
--- a/rest-twitter/service/TweetRetriever.py
+++ b/rest-twitter/service/TweetRetriever.py
@@ -3,10 +3,12 @@ from birdy.twitter import AppClient, TwitterClientError
 
 class TweetRetriever:
 
-    def __init__(self):
+    def __init__(self, dev_env_name_30d='myDevEnv'):
         '''Initialize TweetRetriever. For security, API keys associated with
-            your Twitter app should be present in environment variables.'''
+            your Twitter app should be present in environment variables.
+            dev_env_name_30d = dev environment label for your app displayed on Twitter's developer page'''
 
+        self.devenv_30d = dev_env_name_30d
         # Load consumer keys from environment variables.
         self.consumer_key = os.environ.get('TWITTER_API_KEY')
         self.consumer_secret = os.environ.get('TWITTER_API_KEY_SECRET')
@@ -17,7 +19,8 @@ class TweetRetriever:
             print('Twitter API key and secret key loaded')
         self.client = self._initialize_client()
         if self.client is not None:
-            self.resource_search_tweets = self.client.api.search.tweets
+            self.resource_search_7day = self.client.api.search.tweets
+            self.resource_search_30day = self.client.api['tweets/search/30day/{:s}'.format(self.devenv_30d)]
         else:
             print('Failed to initialize TweetRetriever')
 
@@ -36,31 +39,56 @@ class TweetRetriever:
             client = None
         return client
 
-    def get_tweets(self, trend, latitude, longitude, radius='25mi'):
-        '''Returns tweets from Twitter's search/trends endpoint; there may be zero tweets!'''
+    def get_tweets(self, trend, latitude, longitude, radius='25mi', endpoint='7day'):
+        '''Returns tweets from Twitter's search/trends endpoint; there may be zero tweets!
+            Valid endpoints are '7day' and '30day'.'''
 
         # Enclose trend in double-quotes for exact matching unless it's a hashtag
         trend = '"' + trend + '"' if trend[0] == '#' else trend
-        # Set up filters to ignore retweets (and replies, if desired)
-        filters = '-filter:retweets' #AND -filter:replies'
-        # Set up query and geocode strings according to Twitter's API specification
-        query_str = '{:s} AND {:s}'.format(trend, filters)
-        geocode_str = '{:s},{:s},{:s}'.format(str(latitude), str(longitude), radius)
-        # Get response from Twitter!
-        #   * result_mode 'recent' returns all recent tweets (not just popular ones)
-        #   * tweet_mode 'extended' prevents tweet text from being truncated
-        #   * include_entities 'false' prevents Twitter from giving us extra unnecessary info
-        try:
-            response = self.resource_search_tweets.get(q=query_str,
-                                                       geocode=geocode_str,
-                                                       lang='en',
-                                                       result_type='recent',
-                                                       tweet_mode='extended',
-                                                       count=100,
-                                                       include_entities='false')
-            # Extract only the tweet text from the response
-            tweets = [s.full_text for s in response.data.statuses]
-        except Exception as ex:
-            print('Error: {:s}'.format(str(ex)))
-            tweets = None
-        return tweets
+
+        if endpoint == '7day':
+            # Twitter's 7-day search endpoint is preferred; high density of tweets, though incomplete
+
+            # Set up filters to ignore retweets (and replies, if desired)
+            filters = '-filter:retweets' #AND -filter:replies'
+            # Set up query and geocode strings according to Twitter's API specification
+            query_str = '{:s} AND {:s}'.format(trend, filters)
+            geocode_str = '{:s},{:s},{:s}'.format(str(latitude), str(longitude), radius)
+            # Get response from Twitter!
+            #   * result_mode 'recent' returns all recent tweets (not just popular ones)
+            #   * tweet_mode 'extended' prevents tweet text from being truncated
+            #   * include_entities 'false' prevents Twitter from giving us extra unnecessary info
+            try:
+                response = self.resource_search_7day.get(q=query_str,
+                                                           geocode=geocode_str,
+                                                           lang='en',
+                                                           result_type='recent',
+                                                           tweet_mode='extended',
+                                                           count=100,
+                                                           include_entities='false')
+                # Extract only the tweet text from the response
+                tweets = [s.full_text for s in response.data.statuses]
+            except Exception as ex:
+                print('Error: {:s}'.format(str(ex)))
+                tweets = None
+            return tweets
+
+        elif endpoint == '30day':
+            # Twitter's 30-day search endpoint within a free sandbox environment is not preferred,
+            #  since in testing it returns a very low temporal density of tweets (many fewer than 7-day)
+
+            # Build the geocode and query strings for the 30-day endpoint (different format than 7-day)
+            geocode_str = 'point_radius:[{:s} {:s} {:s}]'.format(str(longitude), str(latitude), radius)
+            query_str = '{:s} lang:en {:s}'.format(trend, geocode_str)
+            try:
+                # Response is also slightly different than 7-day search response
+                print(query_str)
+                response = self.resource_search_30day.get(query=query_str)
+                tweets = [result.text for result in response.data['results']]
+            except Exception as ex:
+                print('Error: {:s}'.format(str(ex)))
+                tweets = None
+            return tweets
+        
+        else:
+            raise NotImplementedError('Requested Twitter endpoint must be 7day or 30day')

--- a/rest-twitter/service/TweetRetriever_Test.py
+++ b/rest-twitter/service/TweetRetriever_Test.py
@@ -3,23 +3,17 @@
 # Make sure to run with e.g. "env TWITTER_API_KEY=xxx TWITTER_API_KEY_SECRET=xxx python TweetRetriever_Test.py"
 
 from TweetRetriever import TweetRetriever
-from vaderSent import SentimentAnalyzer
-import time
-from config.location_service_config import CACHE
-from service.Location_Service import *
-import os
 
-tr = TweetRetriever()
-vs = SentimentAnalyzer()
-path = os.path.join(os.path.curdir, CACHE['location'])
-ls = LocationService(path, CACHE['dump_interval'])
+tr = TweetRetriever(dev_env_name_30d='myDevEnv')
 
-coords = ls.get_coordinates_for_city({'city': 'denver', 'country': 'US'})
-tweets = tr.get_tweets('#ClimateStrike','39.7392358','-104.990251')
+tweets_7d  = tr.get_tweets('Barr','39.7392358','-104.990251', endpoint='7day')
+tweets_30d = tr.get_tweets('Barr','39.7392358','-104.990251', endpoint='30day')
 
-for each in tweets:
-    score = vs.sentimentAnalyzerScores(each)
-    print(each, score)
-    print("#####")
-avgSent = vs.computeSentiment(tweets)
-print(avgSent)
+for txt, tweets in zip(('7d', '30d'), (tweets_7d, tweets_30d)):
+    print('*********************************')
+    print('*********************************')
+    print('*******', txt, 'number of tweets =', len(tweets))
+    print('*********************************')
+    print('*********************************')
+    for each in tweets:
+        print(repr(each))


### PR DESCRIPTION
This pull request adds the ability to hit Twitter's 30-day tweet search endpoint. However, it seems that the free sandbox environment does not allow us to see full-text tweets, nor does it provide full-fidelity tweet data. The 7-day endpoint often returns more tweets and the returned tweets often have a much higher temporal density.

We should merge this pull request, but not actually use the 30-day functionality at this time. No code that uses the `TweetRetriever` class needs to be changed to query the 7-day endpoint. Options have been added that allow the user to explicitly switch to the 30-day endpoint.